### PR TITLE
Fixed dependency processing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Add f5-ctlr-agent to the `requirements.txt` file for your project. Use [editable
 ```
 [-e] git+https://git.myproject.org/MyProject#egg=MyProject
 ```
+To install in your project run `pip install --process-dependency-links -r requirements.txt`.
 
 # Filing Issues
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e git+https://github.com/f5devcentral/f5-cccl.git@d55c2d24b03a50ecd71803501ea2db1dfed5efb5#egg=f5-cccl
 pyinotify==0.9.6
 requests==2.9.1
 pytest==3.0.2

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,18 @@ from setuptools import find_packages
 
 import f5_ctlr_agent
 
-install_requirements = map(
-    lambda x: str(x.req), parse_reqs('./requirements.txt', session='setup')
-)
+# NOTE: This package needs to be installed with pip --process-dependency-links
 
-print('install requirements', install_requirements)
+install_reqs = []
+install_links = []
+install_gen = parse_reqs('./requirements.txt', session='setup')
+
+for req in install_gen:
+    install_reqs.append(str(req.req))
+    if req.link is not None:
+        install_links.append(str(req.link) + '-0')
+
+print('install requirements', install_reqs)
 setup(
     name='f5-ctlr-agent',
     description='F5 Networks Controller Agent',
@@ -35,9 +42,7 @@ setup(
     url='https://github.com/f5devcentral/f5-ctlr-agent',
     keywords=['F5', 'big-ip'],
     scripts=['f5_ctlr_agent/bigipconfigdriver.py'],
-    dependency_links=[
-        'git+https://github.com/f5devcentral/f5-cccl.git@d55c2d24b03a50ecd71803501ea2db1dfed5efb5#egg=f5-cccl'
-    ],
-    install_requires=['f5-cccl']+install_requirements,
+    dependency_links=install_links,
+    install_requires=install_reqs,
     packages=find_packages(exclude=['*test', '*.test.*', 'test*', 'test']),
 )


### PR DESCRIPTION
Problem:
 f5-cccl was not being installed properly by setup.py causing the pip
 install to fail when this package was installed by other packages.

Solution:
 Add processing to setup.py to handle dependency links so that they can
 be installed in other packages by pip using the
 --process-dependency-links flag.