### PR TITLE
Added bandit back to requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mock
 flake8==3.4.1
 pytest-cov==2.5.1
 coveralls==1.1
+bandit==1.4.0


### PR DESCRIPTION
Problem:
 The requirement for bandit was accidentally left out during the
 migration.

Solution:
 Add that requirement back in.