### PR TITLE
Split requirements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
         - PKG_VERSION=$(python -c "import f5_ctlr_agent; print f5_ctlr_agent.__version__")
 install:
     - pip install tox
+    - pip install -r ./agent-build-requirements.txt
     - python ./setup.py install
 script:
     - tox -e style

--- a/agent-build-requirements.txt
+++ b/agent-build-requirements.txt
@@ -1,0 +1,7 @@
+-e git+https://github.com/f5devcentral/f5-cccl.git@06254f6f3b399da8b7e830847d59add55c299f97#egg=f5-cccl
+pytest==3.0.2
+mock==2.0.0
+flake8==3.4.1
+pytest-cov==2.5.1
+coveralls==1.1
+bandit==1.4.0

--- a/agent-runtime-requirements.txt
+++ b/agent-runtime-requirements.txt
@@ -1,9 +1,3 @@
 -e git+https://github.com/f5devcentral/f5-cccl.git@06254f6f3b399da8b7e830847d59add55c299f97#egg=f5-cccl
 pyinotify==0.9.6
 requests==2.9.1
-pytest==3.0.2
-mock
-flake8==3.4.1
-pytest-cov==2.5.1
-coveralls==1.1
-bandit==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ import f5_ctlr_agent
 
 install_reqs = []
 install_links = []
-install_gen = parse_reqs('./requirements.txt', session='setup')
+install_gen = parse_reqs('./agent-runtime-requirements.txt', session='setup')
 
 for req in install_gen:
     install_reqs.append(str(req.req))

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ basepython =
     coverage: python
 passenv= COVERALLS_REPO_TOKEN
 deps=
-    -rrequirements.txt
+    -ragent-build-requirements.txt
+    -ragent-runtime-requirements.txt
 commands =
     style: flake8 ./f5_ctlr_agent
     style: pylint ./f5_ctlr_agent


### PR DESCRIPTION
Problem:
 The requirements that are only needed for our build purposes were being
 installed with this package when they should not have been. This also
 caused an issue with attributions since we were pulling in our
 build requirements which do not need to attributed since they are not
 used during runtime.

Solution:
 Split requirements into build and runtime requirements files.