### PR TITLE
Modified parameter passed in to call delete_unused_ssl_profiles

### DIFF
--- a/agent-build-requirements.txt
+++ b/agent-build-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@568a858f761645233847e0b28b5b98e8e79c95d0#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@7109ac713af422af18206bcf5db3b500a2155a4a#egg=f5-cccl
 pytest==3.0.2
 mock==2.0.0
 flake8==3.4.1

--- a/agent-runtime-requirements.txt
+++ b/agent-runtime-requirements.txt
@@ -1,3 +1,3 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@568a858f761645233847e0b28b5b98e8e79c95d0#egg=f5-cccl
+-e git+https://github.com/russokj/f5-cccl.git@7109ac713af422af18206bcf5db3b500a2155a4a#egg=f5-cccl
 pyinotify==0.9.6
 requests==2.9.1

--- a/f5_ctlr_agent/bigipconfigdriver.py
+++ b/f5_ctlr_agent/bigipconfigdriver.py
@@ -120,6 +120,10 @@ class CloudServiceManager():
         """Apply the net configuration to the BIG-IP."""
         return self._cccl.apply_net_config(config)
 
+    def get_proxy(self):
+        """Called from 'CCCL' delete_unused_ssl_profiles"""
+        return self._cccl.get_proxy()
+
 
 class IntervalTimerError(Exception):
     def __init__(self, msg):
@@ -252,8 +256,8 @@ def _create_custom_profiles(mgmt, partition, custom_profiles):
     return incomplete
 
 
-def _delete_unused_ssl_profiles(mgmt, partition, config):
-    return delete_unused_ssl_profiles(mgmt, partition, config)
+def _delete_unused_ssl_profiles(mgr, partition, config):
+    return delete_unused_ssl_profiles(mgr, partition, config)
 
 
 class ConfigHandler():
@@ -395,7 +399,7 @@ class ConfigHandler():
                 # Manually delete custom profiles (if needed)
                 if mgr.get_schema_type() == 'ltm':
                     _delete_unused_ssl_profiles(
-                        mgr.mgmt_root(),
+                        mgr,
                         partition,
                         cfg_ltm)
 


### PR DESCRIPTION
Problem:  Need access to the F5CloudServiceManager object in
the delete_unused_ssl_profiles function defined in CCCL. This
allows the function to make use of the virtual objects previously
created by apply_ltm_config().  Otherwise, the virtuals would
have to be re-retrieved from the Big-IP.

Solution: Passed in the manager object to the call which has the
required information already stored.  This information is needed
to help prune the delete list for profiles (to remove those held
by whitelisted virtuals).