### PR TITLE
upgarde to python3.8

### DIFF
--- a/f5_ctlr_agent/bigipconfigdriver.py
+++ b/f5_ctlr_agent/bigipconfigdriver.py
@@ -175,14 +175,14 @@ class IntervalTimer(object):
         return adjusted_interval
 
     def _run(self):
-        start_time = time.clock()
+        start_time = time.process_time()
         try:
             self._cb()
         except Exception:
             log.exception('Unexpected error')
         finally:
             with self._lock:
-                stop_time = time.clock()
+                stop_time = time.process_time()
                 self._set_execution_time(start_time, stop_time)
                 if self._running:
                     self.start()


### PR DESCRIPTION
time.clock() is deprecated and removed in python3.7. Replacing with time.process_time()